### PR TITLE
Allow correct highlighting of nested block comments

### DIFF
--- a/userDefineLang_rust.xml
+++ b/userDefineLang_rust.xml
@@ -36,7 +36,7 @@
         </KeywordLists>
         <Styles>
             <WordsStyle name="DEFAULT" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
-            <WordsStyle name="COMMENTS" fgColor="AAAAAA" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
+            <WordsStyle name="COMMENTS" fgColor="AAAAAA" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="256" />
             <WordsStyle name="LINE COMMENTS" fgColor="AAAAAA" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
             <WordsStyle name="NUMBERS" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
             <WordsStyle name="KEYWORDS1" fgColor="AA0000" bgColor="FFFFFF" fontName="" fontStyle="2" nesting="0" />


### PR DESCRIPTION
Rust block comments can be nested. This change allows the syntax highlighter to reflect that.