### PR TITLE
Lifetime highlighting

### DIFF
--- a/darkThemeCompatible.xml
+++ b/darkThemeCompatible.xml
@@ -1,0 +1,64 @@
+<NotepadPlus>
+    <UserLang name="Rust-lang" ext="rs" udlVersion="2.1">
+        <Settings>
+            <Global caseIgnored="no" allowFoldOfComments="yes" foldCompact="no" forcePureLC="0" decimalSeparator="0" />
+            <Prefix Keywords1="no" Keywords2="no" Keywords3="no" Keywords4="yes" Keywords5="yes" Keywords6="yes" Keywords7="no" Keywords8="no" />
+        </Settings>
+        <KeywordLists>
+            <Keywords name="Comments">00// 01 02 03/* 04*/</Keywords>
+            <Keywords name="Numbers, prefix1"></Keywords>
+            <Keywords name="Numbers, prefix2"></Keywords>
+            <Keywords name="Numbers, extras1"></Keywords>
+            <Keywords name="Numbers, extras2"></Keywords>
+            <Keywords name="Numbers, suffix1"></Keywords>
+            <Keywords name="Numbers, suffix2"></Keywords>
+            <Keywords name="Numbers, range"></Keywords>
+            <Keywords name="Operators1">( ) [ ] ... . , ^ % &gt; &lt; ! = + - | : =&gt; &gt;&gt; &lt;&lt; ; ::</Keywords>
+            <Keywords name="Operators2">_</Keywords>
+            <Keywords name="Folders in code1, open">{</Keywords>
+            <Keywords name="Folders in code1, middle"></Keywords>
+            <Keywords name="Folders in code1, close">}</Keywords>
+            <Keywords name="Folders in code2, open"></Keywords>
+            <Keywords name="Folders in code2, middle"></Keywords>
+            <Keywords name="Folders in code2, close"></Keywords>
+            <Keywords name="Folders in comment, open"></Keywords>
+            <Keywords name="Folders in comment, middle"></Keywords>
+            <Keywords name="Folders in comment, close"></Keywords>
+            <Keywords name="Keywords1">as break continue do else false fn for if impl in let loop match mod return self super true trait type unsafe use while move</Keywords>
+            <Keywords name="Keywords2">mut static extern struct enum ref box const priv pub crate</Keywords>
+            <Keywords name="Keywords3">f16 f32 f64 isize i8 i16 i32 i64 usize u8 u16 u32 u64 bool str String</Keywords>
+            <Keywords name="Keywords4">macro_rules! fmt! format! env! try! stringify! include! include_str! include_bin! error! warn! info! debug! assert! assert_eq! println! print! write! panic! vec! ident expr ty pat block</Keywords>
+            <Keywords name="Keywords5">skipp \&apos; &amp;\&apos;</Keywords>
+            <Keywords name="Keywords6">* &amp; $ &amp;mut</Keywords>
+            <Keywords name="Keywords7"></Keywords>
+            <Keywords name="Keywords8"></Keywords>
+            <Keywords name="Delimiters">00&quot; 01\ 02&quot; 03#[ 04 05] 06 07 08 09 10 11 12 13 14 15 16 17 18 19 20 21 22 23</Keywords>
+        </KeywordLists>
+        <Styles>
+            <WordsStyle name="DEFAULT" fgColor="E2E2E2" bgColor="FFFFFF" colorStyle="1" fontName="" fontStyle="0" nesting="0" />
+            <WordsStyle name="COMMENTS" fgColor="AAAAAA" bgColor="FFFFFF" colorStyle="1" fontName="" fontStyle="0" nesting="256" />
+            <WordsStyle name="LINE COMMENTS" fgColor="AAAAAA" bgColor="FFFFFF" colorStyle="1" fontName="" fontStyle="0" nesting="0" />
+            <WordsStyle name="NUMBERS" fgColor="C0C0C0" bgColor="FFFFFF" colorStyle="1" fontName="" fontStyle="0" nesting="0" />
+            <WordsStyle name="KEYWORDS1" fgColor="FFAA00" bgColor="FFFFFF" colorStyle="1" fontName="" fontStyle="0" nesting="0" />
+            <WordsStyle name="KEYWORDS2" fgColor="FFAA00" bgColor="FFFFFF" colorStyle="1" fontName="" fontStyle="0" nesting="0" />
+            <WordsStyle name="KEYWORDS3" fgColor="FFFFFF" bgColor="FFFFFF" colorStyle="1" fontName="" fontStyle="0" nesting="0" />
+            <WordsStyle name="KEYWORDS4" fgColor="F8F8F8" bgColor="EAEAEA" colorStyle="1" fontName="" fontStyle="0" nesting="0" />
+            <WordsStyle name="KEYWORDS5" fgColor="FFFF00" bgColor="FFFFFF" colorStyle="1" fontName="" fontStyle="0" nesting="0" />
+            <WordsStyle name="KEYWORDS6" fgColor="FFAA00" bgColor="000000" colorStyle="1" fontName="" fontStyle="0" nesting="0" />
+            <WordsStyle name="KEYWORDS7" fgColor="FFAA00" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
+            <WordsStyle name="KEYWORDS8" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
+            <WordsStyle name="OPERATORS" fgColor="FFAA00" bgColor="FFFFFF" colorStyle="1" fontName="" fontStyle="0" nesting="0" />
+            <WordsStyle name="FOLDER IN CODE1" fgColor="FFAA00" bgColor="FFFFFF" colorStyle="1" fontName="" fontStyle="0" nesting="0" />
+            <WordsStyle name="FOLDER IN CODE2" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
+            <WordsStyle name="FOLDER IN COMMENT" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
+            <WordsStyle name="DELIMITERS1" fgColor="55E439" bgColor="FFFFFF" colorStyle="1" fontName="" fontStyle="0" nesting="0" />
+            <WordsStyle name="DELIMITERS2" fgColor="750000" bgColor="FFFFFF" colorStyle="1" fontName="" fontStyle="0" nesting="0" />
+            <WordsStyle name="DELIMITERS3" fgColor="0000FF" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
+            <WordsStyle name="DELIMITERS4" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
+            <WordsStyle name="DELIMITERS5" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
+            <WordsStyle name="DELIMITERS6" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
+            <WordsStyle name="DELIMITERS7" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
+            <WordsStyle name="DELIMITERS8" fgColor="000000" bgColor="FFFFFF" fontName="" fontStyle="0" nesting="0" />
+        </Styles>
+    </UserLang>
+</NotepadPlus>

--- a/darkThemeCompatible.xml
+++ b/darkThemeCompatible.xml
@@ -28,7 +28,7 @@
             <Keywords name="Keywords2">mut static extern struct enum ref box const priv pub crate</Keywords>
             <Keywords name="Keywords3">f16 f32 f64 isize i8 i16 i32 i64 usize u8 u16 u32 u64 bool str String</Keywords>
             <Keywords name="Keywords4">macro_rules! fmt! format! env! try! stringify! include! include_str! include_bin! error! warn! info! debug! assert! assert_eq! println! print! write! panic! vec! ident expr ty pat block</Keywords>
-            <Keywords name="Keywords5">skipp \&apos; &amp;\&apos;</Keywords>
+            <Keywords name="Keywords5">\&apos; &amp;\&apos;</Keywords>
             <Keywords name="Keywords6">* &amp; $ &amp;mut</Keywords>
             <Keywords name="Keywords7"></Keywords>
             <Keywords name="Keywords8"></Keywords>

--- a/userDefineLang_rust.xml
+++ b/userDefineLang_rust.xml
@@ -29,7 +29,7 @@
             <Keywords name="Keywords3">f16 f32 f64 isize i8 i16 i32 i64 usize u8 u16 u32 u64 bool str String</Keywords>
             <Keywords name="Keywords4">macro_rules! fmt! format! env! try! stringify! include! include_str! include_bin! error! warn! info! debug! assert! assert_eq! println! print! write! panic! vec! ident expr ty pat block</Keywords>
             <Keywords name="Keywords5"></Keywords>
-            <Keywords name="Keywords6">* &amp; &apos; $ &amp;mut</Keywords>
+            <Keywords name="Keywords6">* &amp; \&apos; $ &amp;mut &amp;\&apos;</Keywords>
             <Keywords name="Keywords7"></Keywords>
             <Keywords name="Keywords8"></Keywords>
             <Keywords name="Delimiters">00&quot; 01\ 02&quot; 03#[ 04 05] 06 07 08 09 10 11 12 13 14 15 16 17 18 19 20 21 22 23</Keywords>

--- a/zenburn.xml
+++ b/zenburn.xml
@@ -29,7 +29,7 @@
             <Keywords name="Keywords3">f16 f32 f64 isize i8 i16 i32 i64 usize u8 u16 u32 u64 bool str String</Keywords>
             <Keywords name="Keywords4">macro_rules! fmt! format! env! try! stringify! include! include_str! include_bin! error! warn! info! debug! assert! assert_eq! println! print! write! panic! vec! ident expr ty pat block</Keywords>
             <Keywords name="Keywords5"></Keywords>
-            <Keywords name="Keywords6">* &amp; &apos; $ &amp;mut</Keywords>
+            <Keywords name="Keywords6">* &amp; \&apos; $ &amp;mut &amp;\&apos;</Keywords>
             <Keywords name="Keywords7"></Keywords>
             <Keywords name="Keywords8"></Keywords>
             <Keywords name="Delimiters">00&quot; 01\&quot; 02&quot; 03#[ 04 05] 06#![ 07 08] 09r&quot; 10 11&quot; 12&apos; 13\&apos; 14&apos; 15 16 17 18 19 20 21 22 23</Keywords>


### PR DESCRIPTION
Even though &apos; was already in the keywords, it didn't properly highlight because there was no escape character before it. Also, added another keyword to highlight the reference lifetime type